### PR TITLE
1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2021-07-12
 ### Fixed
 - Make dependencies explicit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make dependencies explicit.
+
 
 ## [0.2.2] - 2021-03-30
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-infra
 $ vtex COMMAND
 running command...
 $ vtex (-v|--version|version)
-@vtex/cli-plugin-infra/0.2.2 linux-x64 node-v12.21.0
+@vtex/cli-plugin-infra/0.2.2 linux-x64 node-v12.22.1
 $ vtex --help [COMMAND]
 USAGE
   $ vtex COMMAND

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-infra
 $ vtex COMMAND
 running command...
 $ vtex (-v|--version|version)
-@vtex/cli-plugin-infra/0.2.2 linux-x64 node-v12.22.1
+@vtex/cli-plugin-infra/1.0.0 linux-x64 node-v12.22.1
 $ vtex --help [COMMAND]
 USAGE
   $ vtex COMMAND
@@ -63,7 +63,7 @@ EXAMPLES
   vtex infra install infra-service@0.0.1
 ```
 
-_See code: [build/commands/infra/install.ts](https://github.com/vtex/cli-plugin-infra/blob/v0.2.2/build/commands/infra/install.ts)_
+_See code: [build/commands/infra/install.ts](https://github.com/vtex/cli-plugin-infra/blob/v1.0.0/build/commands/infra/install.ts)_
 
 ## `vtex infra:list [NAME]`
 
@@ -91,7 +91,7 @@ EXAMPLES
   vtex infra ls
 ```
 
-_See code: [build/commands/infra/list.ts](https://github.com/vtex/cli-plugin-infra/blob/v0.2.2/build/commands/infra/list.ts)_
+_See code: [build/commands/infra/list.ts](https://github.com/vtex/cli-plugin-infra/blob/v1.0.0/build/commands/infra/list.ts)_
 
 ## `vtex infra:update`
 
@@ -110,5 +110,5 @@ EXAMPLE
   vtex infra update
 ```
 
-_See code: [build/commands/infra/update.ts](https://github.com/vtex/cli-plugin-infra/blob/v0.2.2/build/commands/infra/update.ts)_
+_See code: [build/commands/infra/update.ts](https://github.com/vtex/cli-plugin-infra/blob/v1.0.0/build/commands/infra/update.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-infra",
   "description": "vtex plugin infra",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "bugs": "https://github.com/vtex/cli-plugin-infra/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
+    "@vtex/api": "^3.77.0",
+    "chalk": "^4.1.1",
     "ora": "^5.3.0",
     "pad": "^3.2.0",
     "ramda": "~0.25.0",
+    "semver": "^7.3.5",
     "tslib": "^1"
   },
   "devDependencies": {
@@ -27,7 +30,6 @@
     "nodemon": "^2.0.2",
     "nodemon-notifier-cli": "https://github.com/Slessi/nodemon-notifier-cli.git",
     "prettier": "^2.0.1",
-    "semver": "^7.3.2",
     "ts-jest": "^25.2.1",
     "ts-node": "^8",
     "typescript": "^3.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,6 +1189,45 @@
     tar-fs "^2.0.0"
     xss "^1.0.6"
 
+"@vtex/api@^3.77.0":
+  version "3.77.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.77.1.tgz#7ac5ab2e9cd43e69c711399a6ed8daea6c19db82"
+  integrity sha512-Dm+fM3BGtGIygeajgQjEM5ZhGMpf5Pwd3y/uAhyGs3LdCQB5QyYfeUkl6td70PXJirNizQrEWt7jNE8s6Ww4dw==
+  dependencies:
+    "@types/koa" "^2.0.48"
+    "@types/koa-compose" "^3.2.3"
+    "@wry/equality" "^0.1.9"
+    agentkeepalive "^4.0.2"
+    apollo-datasource "^0.3.1"
+    apollo-server-core "^2.4.8"
+    apollo-server-errors "^2.2.1"
+    archiver "^3.0.0"
+    axios "^0.18.0"
+    axios-retry "^3.1.2"
+    bluebird "^3.5.4"
+    chalk "^2.4.2"
+    co-body "^6.0.0"
+    cookie "^0.3.1"
+    dataloader "^1.4.0"
+    fs-extra "^7.0.0"
+    graphql "^0.13.2"
+    graphql-extensions "^0.5.7"
+    graphql-tools "^3.1.1"
+    graphql-upload "^8.0.4"
+    js-base64 "^2.5.1"
+    koa-compose "^4.1.0"
+    lru-cache "^5.1.1"
+    mime-types "^2.1.12"
+    p-limit "^2.2.0"
+    qs "^6.5.1"
+    querystring "^0.2.0"
+    ramda "^0.26.0"
+    rwlock "^5.0.0"
+    semver "^5.5.1"
+    stats-lite vtex/node-stats-lite#dist
+    tar-fs "^2.0.0"
+    xss "^1.0.6"
+
 "@vtex/cli-plugin-abtest@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-abtest/-/cli-plugin-abtest-0.0.5.tgz#3fb5e95f7c26be2a8c1aae0eca5eb0b49d8cc077"
@@ -2513,6 +2552,14 @@ chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -6355,6 +6402,13 @@ lru-cache@^5.0.0, lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -7932,6 +7986,13 @@ semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
@@ -9434,6 +9495,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
New major with plugins dependencies explicit.

#### What problem is this solving?
On toolbelt 2.x, our plugins are using implicitly dependencies from the toolbelt. On 3.x, it is not running well, because the way that we are doing is structurally different from 2.x.

When we install a plugin on toolbelt 3.x, using vtex plugins install [PLUGIN], it is installed on /Users/william/.local/share/vtex/node_modules/@vtex/[PLUGIN]. To solve the problem of dependencies that the plugin has of toolbelt, a symlink is done from /Users/william/.config/yarn/global/node_modules/vtex to /Users/william/.local/share/vtex/node_modules/vtex. Diferent of 2.x, in this case the plugin cannot find its implicits dependencies inside of /Users/william/.local/share/vtex/node_modules/vtex, because the way that Node.js search, looks only for path/node_molules and above "recursively". Look more about how a require works [here](https://www.freecodecamp.org/news/requiring-modules-in-node-js-everything-you-need-to-know-e7fbd119be8/).

Understanding that our plugins on 3.x are not getting dependencies from inside the toolbelt, we have two initial options: Do another symlink of all dependencies from the toolbelt to the plugin, or install all dependencies explicitly. The second option looks better because we will not have problems with different versions in dev or production environment.

#### How should this be manually tested?
Linking this plugin on toolbelt 3.x.

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`